### PR TITLE
Update footer to align with coronawarn.app

### DIFF
--- a/src/data/global.json
+++ b/src/data/global.json
@@ -42,6 +42,10 @@
                             "url": "https://www.coronawarn.app/en/privacy/"
                         },
                         {
+                            "title": "Accessibility statement",
+                            "url": "https://coronawarn.app/en/accessibility"
+                        },
+                        {
                             "title": "Terms of use",
                             "url": "https://www.coronawarn.app/en/terms-of-use/"
                         },
@@ -171,6 +175,10 @@
                         {
                             "title": "Datenschutzerklärung",
                             "url": "https://www.coronawarn.app/de/privacy/"
+                        },
+                        {
+                            "title": "Barrierefreiheits&shy;erklärung",
+                            "url": "coronawarn.app/de/accessibility"
                         },
                         {
                             "title": "Nutzungsbedingungen",


### PR DESCRIPTION
## Description

This PR updates the footer to match the one from coronawarn.app.

## What was changed?

The file `global.json` which includes the settings for the footer.

## Screenshots

| DE | EN |
|---|---|
| <img width="1440" alt="Bildschirmfoto 2022-07-24 um 11 52 30" src="https://user-images.githubusercontent.com/67682506/180641885-6484d339-b039-41e9-a2ed-ba1d2e16a21e.png"> | <img width="1440" alt="Bildschirmfoto 2022-07-24 um 11 52 38" src="https://user-images.githubusercontent.com/67682506/180641971-e94c7ffa-90ae-40c7-a766-e2c1ce85b4a6.png"> |
