### PR TITLE
Fix badge open issue count error 

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,7 +63,7 @@ The following channels are available for discussions, feedback, and support requ
 
 | Type                     | Channel                                                |
 | ------------------------ | ------------------------------------------------------ |
-| **General discussion, issues, bugs**   | <a href="https://github.com/corona-warn-app/cwa-event-landingpage/issues/new/choose" title="General Discussion"><img src="https://img.shields.io/github/issues/corona-warn-app/cwa-event-landingpage/question.svg?style=flat-square"></a> </a>   |
+| **General discussion, issues, bugs**   | <a href="https://github.com/corona-warn-app/cwa-event-landingpage/issues/new/choose" title="General Discussion"><img src="https://img.shields.io/github/issues/corona-warn-app/cwa-event-landingpage?style=flat-square"></a> |
 | **Other requests**    | <a href="mailto:corona-warn-app.opensource@sap.com" title="Email CWA Team"><img src="https://img.shields.io/badge/email-CWA%20team-green?logo=mail.ru&style=flat-square&logoColor=white"></a> |
 
 ## How to contribute


### PR DESCRIPTION
This PR corrects the wrong display of the open issues count in the README file. The error has been propagated to multiple repositories. I corrected it in the main ones already.

BEFORE:

![image](https://user-images.githubusercontent.com/66998419/199307615-04ff4223-0c80-4fea-92aa-2c8a5a0c4f3a.png)

AFTER:

![image](https://user-images.githubusercontent.com/66998419/199307805-76cc15ca-57eb-4c0c-88e8-df220540595e.png)




