### PR TITLE
Remove TAN hotline info from footer

### DIFF
--- a/src/data/global.json
+++ b/src/data/global.json
@@ -116,22 +116,7 @@
                             "title": "+49 30 498 75401",
                             "url": "tel:+49 30 498 75401"
                         }
-                    ],
-                    "testid": "hotline-app"
-                },
-                {
-                    "title": "Hotline TAN",
-                    "links": [
-                        {
-                            "title": "0800 7540002",
-                            "url": "tel:08007540002"
-                        },
-                        {
-                            "title": "+49 30 498 75402",
-                            "url": "tel:+49 30 498 75402"
-                        }
-                    ],
-                    "testid": "hotline-tan"
+                    ]
                 }
             ],
             "copyright": {
@@ -248,22 +233,7 @@
                             "title": "+49 30 498 75401",
                             "url": "tel:+49 30 498 75401"
                         }
-                    ],
-                    "testid": "hotline-app"
-                },
-                {
-                    "title": "Hotline TAN",
-                    "links": [
-                        {
-                            "title": "0800 7540002",
-                            "url": "tel:08007540002"
-                        },
-                        {
-                            "title": "+49 30 498 75402",
-                            "url": "tel:+49 30 498 75402"
-                        }
-                    ],
-                    "testid": "hotline-tan"
+                    ]
                 }
             ],
             "copyright": {

--- a/src/data/global.json
+++ b/src/data/global.json
@@ -120,7 +120,7 @@
                 }
             ],
             "copyright": {
-                "title": "© 2020-2022 - The authors of the Corona-Warn-App open-source project",
+                "title": "© 2020-2023 - The authors of the Corona-Warn-App open-source project",
                 "url": "https://github.com/corona-warn-app/cwa-event-landingpage/graphs/contributors",
                 "external": true
             }
@@ -237,7 +237,7 @@
                 }
             ],
             "copyright": {
-                "title": "© 2020-2022 - Mitwirkende Personen des Open-Source-Projekts für Corona-Warn-App",
+                "title": "© 2020-2023 - Mitwirkende Personen des Open-Source-Projekts für Corona-Warn-App",
                 "url": "https://github.com/corona-warn-app/cwa-event-landingpage/graphs/contributors",
                 "external": true
             }


### PR DESCRIPTION
## Description
This PR removes the number of the TAN hotline from the footer. It also removes superfluous test IDs. On top of that, it bumps the copyright year in the footer of the page. 

## What was changed?
- `src/data/global.json` (removal of the hotline info, removal of superfluous test IDs & copyright year bump)

## Preview of the changes
You can find a live preview of the changes here: https://cwa-event-landingpage-cmkg3r9bx-ein-tim.vercel.app

---

### This fixes #66.

---
Internal Tracking ID: [EXPOSUREAPP-14643](https://jira-ibs.wbs.net.sap/browse/EXPOSUREAPP-14643)
