### PR TITLE
Revert Accessibility Statement in Footer

### DIFF
--- a/src/data/global.json
+++ b/src/data/global.json
@@ -42,10 +42,6 @@
                             "url": "https://www.coronawarn.app/en/privacy/"
                         },
                         {
-                            "title": "Accessibility statement",
-                            "url": "https://coronawarn.app/en/accessibility"
-                        },
-                        {
                             "title": "Terms of use",
                             "url": "https://www.coronawarn.app/en/terms-of-use/"
                         },
@@ -175,10 +171,6 @@
                         {
                             "title": "Datenschutzerklärung",
                             "url": "https://www.coronawarn.app/de/privacy/"
-                        },
-                        {
-                            "title": "Barrierefreiheits&shy;erklärung",
-                            "url": "coronawarn.app/de/accessibility"
                         },
                         {
                             "title": "Nutzungsbedingungen",


### PR DESCRIPTION
This reverts commit 962411d69fd2332de545c8eadd639a1f1d488442.

In response to https://github.com/corona-warn-app/cwa-event-landingpage/issues/68, we decided to handle the issue by reverting the commit that initally brought in the link to the accessibility statement. As @MikeMcC399 explained, accessibility measures that have been taken on the main website were never taken on this site. 

---
Internal Tracking ID: [EXPOSUREAPP-14671](https://jira-ibs.wbs.net.sap/browse/EXPOSUREAPP-14671)