### PR TITLE
Correct gulpfile reference in package.json

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "corona-warn-app-landingpage",
-  "version": "1.0.0",
+  "version": "2.0.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "corona-warn-app-landingpage",
-      "version": "1.0.0",
+      "version": "2.0.0",
       "license": "Apache-2.0",
       "dependencies": {
         "@babel/core": "^7.18.13",

--- a/package.json
+++ b/package.json
@@ -1,8 +1,8 @@
 {
   "name": "corona-warn-app-landingpage",
-  "version": "1.0.0",
+  "version": "2.0.0",
   "description": "Corona Warn App website coronawarn.app",
-  "main": "gulpfile.js",
+  "main": "gulpfile.mjs",
   "scripts": {
     "start": "gulp",
     "build": "gulp build --production"


### PR DESCRIPTION
This PR corrects the reference to `gulpfile` in `package.json` from `.js` to `.mjs` extension.

- I forgot this in PR https://github.com/corona-warn-app/cwa-event-landingpage/pull/58.

- It does not normally make any difference, since this is a private package which is not getting exported as an npm entity. This is just to clean things up.

